### PR TITLE
Improve dark mode palette

### DIFF
--- a/src/ciemny.sass
+++ b/src/ciemny.sass
@@ -1,15 +1,18 @@
 html.ciemny
 	body
-		background-color: midnightblue
-		color: ghostwhite
+		background-color: #0b1221
+		color: #e2e8f0
 
 	footer
-		color: darkgray
+		color: #94a3b8
 
 		a:link,
 		a:visited
-			color: lightgray
+			color: #cbd5e1
 
 	button
-		color: black
-		background-color: deepskyblue
+		color: #e2e8f0
+		background-color: #2563eb
+
+		&:hover
+			background-color: #3b82f6

--- a/src/ciemny.sass
+++ b/src/ciemny.sass
@@ -1,18 +1,18 @@
 html.ciemny
 	body
-		background-color: #0b1221
-		color: #e2e8f0
+		background-color: #0e1116
+		color: #e5e7eb
 
 	footer
-		color: #94a3b8
+		color: #9ca3af
 
 		a:link,
 		a:visited
-			color: #cbd5e1
+			color: #d1d5db
 
 	button
-		color: #e2e8f0
-		background-color: #2563eb
+		color: #f8fafc
+		background-color: #4b5563
 
 		&:hover
-			background-color: #3b82f6
+			background-color: #6b7280

--- a/src/komponenty/Gra/ciemny.sass
+++ b/src/komponenty/Gra/ciemny.sass
@@ -2,6 +2,6 @@ html.ciemny
 	.gra
 		.przyciskResetu
 			&.jeszczeRaz
-				background-color: limegreen
+				background-color: #22c55e
 			&.naPewno
-				background-color: orange
+				background-color: #f59e0b

--- a/src/komponenty/Literka/ciemny.sass
+++ b/src/komponenty/Literka/ciemny.sass
@@ -1,22 +1,22 @@
 html.ciemny
 	.literka
-		background-color: #111827
+		background-color: #1f242d
 
 		&.dobrze
 			background-color: #16a34a
 
 		&.zle
-			background-color: #334155
+			background-color: #4b5563
 
 		&.przesunieta
 			background-color: #d97706
 
 		&.kursor
-			box-shadow: 0 0 0.4em #3b82f6
+			box-shadow: 0 0 0.4em #9ca3af
 		
 		&.klawisz
 			&:hover
-				background-color: #1e40af
+				background-color: #555b66
 		
 		&.enter
 			background-color: #15803d

--- a/src/komponenty/Literka/ciemny.sass
+++ b/src/komponenty/Literka/ciemny.sass
@@ -1,31 +1,31 @@
 html.ciemny
 	.literka
-		background-color: navy
+		background-color: #111827
 
 		&.dobrze
-			background-color: darkgreen
+			background-color: #16a34a
 
 		&.zle
-			background-color: dimgray
+			background-color: #334155
 
 		&.przesunieta
-			background-color: peru
+			background-color: #d97706
 
 		&.kursor
-			box-shadow: 0 0 0.4em white
+			box-shadow: 0 0 0.4em #3b82f6
 		
 		&.klawisz
 			&:hover
-				background-color: dodgerblue
+				background-color: #1e40af
 		
 		&.enter
-			background-color: darkgreen
+			background-color: #15803d
 
 			&:hover
-				background-color: limegreen
+				background-color: #22c55e
 		
 		&.backspace
-			background-color: darkred
+			background-color: #b91c1c
 
 			&:hover
-				background-color: tomato
+				background-color: #ef4444

--- a/src/komponenty/Okienko/ciemny.sass
+++ b/src/komponenty/Okienko/ciemny.sass
@@ -1,4 +1,4 @@
 html.ciemny
 	.okienko
-		background-color: #0f172a
-		color: #e2e8f0
+		background-color: #12161e
+		color: #e5e7eb

--- a/src/komponenty/Okienko/ciemny.sass
+++ b/src/komponenty/Okienko/ciemny.sass
@@ -1,4 +1,4 @@
 html.ciemny
 	.okienko
-		background-color: midnightblue
-		color: ghostwhite
+		background-color: #0f172a
+		color: #e2e8f0


### PR DESCRIPTION
## Summary
- update global dark theme colors for improved contrast and clarity
- refresh dark mode button, dialog, and status colors to match new palette

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f53a98afc8320a111328960070c2b)