### PR TITLE
Refactor GitHub corner component

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,65 +25,6 @@
 		<title>Damjesowe Wordle</title>
 	</head>
 	<body>
-		<a
-			href="https://github.com/damjes/wordle/"
-			class="github-corner"
-			aria-label="Legu fontkodon en GitHub"
-			><svg
-				width="80"
-				height="80"
-				viewBox="0 0 250 250"
-				style="
-					fill: royalblue;
-					color: #fff;
-					position: absolute;
-					top: 0;
-					border: 0;
-					right: 0;
-				"
-				aria-hidden="true"
-			>
-				<path
-					d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"
-				></path>
-				<path
-					d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
-					fill="currentColor"
-					style="transform-origin: 130px 106px"
-					class="octo-arm"
-				></path>
-				<path
-					d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
-					fill="currentColor"
-					class="octo-body"
-				></path></svg></a
-		><style>
-			.github-corner:hover .octo-arm {
-				animation: octocat-wave 560ms ease-in-out;
-			}
-			@keyframes octocat-wave {
-				0%,
-				100% {
-					transform: rotate(0);
-				}
-				20%,
-				60% {
-					transform: rotate(-25deg);
-				}
-				40%,
-				80% {
-					transform: rotate(10deg);
-				}
-			}
-			@media (max-width: 500px) {
-				.github-corner:hover .octo-arm {
-					animation: none;
-				}
-				.github-corner .octo-arm {
-					animation: octocat-wave 560ms ease-in-out;
-				}
-			}
-		</style>
 		<div id="root"></div>
 		<footer>
 			Copyleft

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,13 @@
+import GithubCorner from './komponenty/GithubCorner/GithubCorner'
 import Gra from './komponenty/Gra/Gra'
 
 function App() {
 	return (
 		<>
+			<GithubCorner
+				href="https://github.com/damjes/wordle/"
+				ariaLabel="Legu fontkodon en GitHub"
+			/>
 			<h1>Damjesowe Wordle</h1>
 			<Gra />
 		</>

--- a/src/komponenty/GithubCorner/GithubCorner.sass
+++ b/src/komponenty/GithubCorner/GithubCorner.sass
@@ -1,0 +1,27 @@
+.github-corner
+	position: absolute
+	top: 0
+	right: 0
+	border: 0
+
+	&__svg
+		position: absolute
+		top: 0
+		right: 0
+
+	&:hover .octo-arm
+		animation: octocat-wave 560ms ease-in-out
+
+@keyframes octocat-wave
+	0%, 100%
+		transform: rotate(0)
+	20%, 60%
+		transform: rotate(-25deg)
+	40%, 80%
+		transform: rotate(10deg)
+
+@media (max-width: 500px)
+	.github-corner:hover .octo-arm
+		animation: none
+	.github-corner .octo-arm
+		animation: octocat-wave 560ms ease-in-out

--- a/src/komponenty/GithubCorner/GithubCorner.tsx
+++ b/src/komponenty/GithubCorner/GithubCorner.tsx
@@ -1,0 +1,37 @@
+import './GithubCorner.sass'
+import './jasny.sass'
+import './ciemny.sass'
+
+type GithubCornerProps = {
+	href: string
+	ariaLabel: string
+}
+
+function GithubCorner({ href, ariaLabel }: GithubCornerProps) {
+	return (
+		<a href={href} className="github-corner" aria-label={ariaLabel}>
+			<svg
+				width="80"
+				height="80"
+				viewBox="0 0 250 250"
+				aria-hidden="true"
+				className="github-corner__svg"
+			>
+				<path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+				<path
+					d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+					fill="currentColor"
+					style={{ transformOrigin: '130px 106px' }}
+					className="octo-arm"
+				></path>
+				<path
+					d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+					fill="currentColor"
+					className="octo-body"
+				></path>
+			</svg>
+		</a>
+	)
+}
+
+export default GithubCorner

--- a/src/komponenty/GithubCorner/ciemny.sass
+++ b/src/komponenty/GithubCorner/ciemny.sass
@@ -1,0 +1,5 @@
+html.ciemny
+	.github-corner
+		&__svg
+			fill: steelblue
+			color: #0e1116

--- a/src/komponenty/GithubCorner/jasny.sass
+++ b/src/komponenty/GithubCorner/jasny.sass
@@ -1,0 +1,4 @@
+.github-corner
+	&__svg
+		fill: royalblue
+		color: #fff


### PR DESCRIPTION
## Summary
- extract the GitHub corner into a dedicated React component with Sass-based styling
- add dark theme colors for the corner to match the app’s dark mode toggle
- remove the inline GitHub corner markup and inline styles from index.html
- parameterize the GitHub corner link and label through props provided by App
- move light theme colors for the corner into a dedicated `jasny.sass` stylesheet
- align dark theme GitHub corner colors with the light theme fill and page background
- adjust dark theme GitHub corner fill to steelblue based on review feedback

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f63e6a6c48320906e016f93a32003)