### PR TITLE
Use strict equality comparisons

### DIFF
--- a/src/komponenty/Gra/Gra.tsx
+++ b/src/komponenty/Gra/Gra.tsx
@@ -38,7 +38,7 @@ setLista((staraLista) => mutacjaListy(2, 'nowa wartość', staraLista))
 function mutacjaListy<T>(pozycja: number, nowyElement: T) {
 	return (lista: Array<T>) =>
 		lista.map((element, indeks) => {
-			if (indeks == pozycja) {
+			if (indeks === pozycja) {
 				return nowyElement
 			} else {
 				return element
@@ -115,7 +115,7 @@ function Gra() {
 	wywołać showModal() na elemencie dialogu
 	*/
 	useEffect(() => {
-		if (treśćOkienka != '') {
+		if (treśćOkienka !== '') {
 			okienko.current?.showModal()
 		}
 	}, [trigerOkienka])
@@ -130,7 +130,7 @@ function Gra() {
 	}
 
 	function backspace() {
-		if (wygranko != Wynik.GraWToku) {
+		if (wygranko !== Wynik.GraWToku) {
 			return // zablokuj usuwanie po wygranej/przegranej
 		}
 		setPotwierdzeniePoddaniaSię(false) // anuluj trwające poddanie się
@@ -138,7 +138,7 @@ function Gra() {
 	}
 
 	function enter() {
-		if (wygranko != Wynik.GraWToku) {
+		if (wygranko !== Wynik.GraWToku) {
 			return // zablokuj enter po wygranej/przegranej
 		}
 
@@ -146,7 +146,7 @@ function Gra() {
 
 		const bieżąceSłowo = próby[numerPróby]
 
-		if (bieżąceSłowo.length != długośćSłowa) {
+		if (bieżąceSłowo.length !== długośćSłowa) {
 			setTytułOkienka('Niewpisane słowo')
 			setTreśćOkienka('Słowo jest za krótkie. Wpisz całe słowo.')
 			setTrigerOkienka(!trigerOkienka)
@@ -167,7 +167,7 @@ function Gra() {
 
 		const nowyNumerPróby = numerPróby + 1 // przyda się numer kolejnej próby
 
-		if (bieżąceSłowo == rozwiązanie) {
+		if (bieżąceSłowo === rozwiązanie) {
 			setWygranko(Wynik.Wygranko)
 			setZmianaTrybuTrudnego(true)
 			setTytułOkienka('Wygranko')
@@ -176,7 +176,7 @@ function Gra() {
 			return
 		}
 
-		if (nowyNumerPróby == liczbaPrób) {
+		if (nowyNumerPróby === liczbaPrób) {
 			// ...o tu się przyda
 			setWygranko(Wynik.Przegranko)
 			setZmianaTrybuTrudnego(true)
@@ -198,7 +198,7 @@ function Gra() {
 
 	function dopiszLiterkę(literka: string) {
 		setPotwierdzeniePoddaniaSię(false) // anuluj trwające poddanie się
-		if (wygranko != Wynik.GraWToku) {
+		if (wygranko !== Wynik.GraWToku) {
 			return // zablokuj wpisywanie po wygranej/przegranej
 		}
 		if (trybTrudny) {
@@ -228,8 +228,8 @@ function Gra() {
 	const słowa = próby.map((słowo, indeks) => (
 		<Słowo
 			etap={
-				wygranko == Wynik.GraWToku
-					? indeks == numerPróby
+				wygranko === Wynik.GraWToku
+					? indeks === numerPróby
 						? 'teraz'
 						: indeks < numerPróby
 						? 'po'
@@ -243,14 +243,14 @@ function Gra() {
 	))
 
 	const napisResetu =
-		wygranko == Wynik.GraWToku
+		wygranko === Wynik.GraWToku
 			? potwierdzeniePoddaniaSię
 				? 'Czy na pewno?'
 				: 'Poddaj się'
 			: 'Zagraj jeszcze raz'
 
 	const funkcjaResetu =
-		wygranko == Wynik.GraWToku
+		wygranko === Wynik.GraWToku
 			? potwierdzeniePoddaniaSię
 				? () => setWygranko(Wynik.Przegranko)
 				: () => setPotwierdzeniePoddaniaSię(true)
@@ -258,17 +258,17 @@ function Gra() {
 
 	const klasaResetu =
 		'przyciskResetu' +
-		(wygranko == Wynik.GraWToku
+		(wygranko === Wynik.GraWToku
 			? potwierdzeniePoddaniaSię
 				? ' naPewno'
 				: ''
 			: ' jeszczeRaz')
 
 	function klawiaturaKlik(e: React.KeyboardEvent<HTMLDivElement>) {
-		if (e.key == 'Enter') {
+		if (e.key === 'Enter') {
 			e.preventDefault()
 			enter()
-		} else if (e.key == 'Backspace') {
+		} else if (e.key === 'Backspace') {
 			backspace()
 		} else {
 			dopiszLiterkę(e.key)
@@ -348,7 +348,7 @@ function Gra() {
 			<button className={klasaResetu} onClick={funkcjaResetu}>
 				{napisResetu}
 			</button>
-			{wygranko == Wynik.Przegranko && (
+			{wygranko === Wynik.Przegranko && (
 				<div className="opisRozwiazania">
 					<p>Rozwiązanie to:</p>
 					<Słowo
@@ -358,7 +358,7 @@ function Gra() {
 					/>
 				</div>
 			)}
-			{wygranko != Wynik.GraWToku && (
+			{wygranko !== Wynik.GraWToku && (
 				<div className="slownik">
 					Sprawdź rozwiązanie w{' '}
 					<a href={'https://sjp.pl/' + rozwiązanie}>

--- a/src/komponenty/Klawiatura/Klawiatura.tsx
+++ b/src/komponenty/Klawiatura/Klawiatura.tsx
@@ -17,7 +17,7 @@ function ustalKolorek(
 }
 
 function ustalWypustkę(literka: string) {
-	if (literka == 't' || literka == 'n') {
+	if (literka === 't' || literka === 'n') {
 		// te literki mają wypustki w układzie Colemaka
 		return ' wypustka'
 	} else {
@@ -74,7 +74,7 @@ function Klawiatura(props: {
 	const literki = props.dozwolone.map((wiersz, indeks) => (
 		<div className="wiersz" key={indeks}>
 			{dajZawartoscWiersza(wiersz)}
-			{indeks == props.dozwolone.length - 1 && znakiSterujące}
+			{indeks === props.dozwolone.length - 1 && znakiSterujące}
 		</div>
 	))
 

--- a/src/komponenty/Slowo/Slowo.tsx
+++ b/src/komponenty/Slowo/Slowo.tsx
@@ -6,10 +6,10 @@ function ustalKlasęWpisywane(
 	indeks: number,
 	długośćSłowa: number
 ) {
-	const gdzieKursor = słowo.length - (długośćSłowa == słowo.length ? 1 : 0)
+	const gdzieKursor = słowo.length - (długośćSłowa === słowo.length ? 1 : 0)
 	// odejmij jeden jeśli na końcu słow
 	// NB: słowo.length to indeks pierwszej wolnej komórki za słowem
-	if (indeks == gdzieKursor) {
+	if (indeks === gdzieKursor) {
 		return 'kursor'
 	} else {
 		return 'nieznana'
@@ -22,7 +22,7 @@ function ustalKlasęWcześniejsze(
 	indeks: number
 ) {
 	const literka = słowo[indeks]
-	if (literka == rozwiązanie[indeks]) {
+	if (literka === rozwiązanie[indeks]) {
 		return 'dobrze'
 	}
 
@@ -74,11 +74,11 @@ function ustalKlasę(
 	rozwiązanie: string,
 	indeks: number
 ) {
-	if (etap == 'przed') {
+	if (etap === 'przed') {
 		return 'nieznana'
 	}
 
-	if (etap == 'teraz') {
+	if (etap === 'teraz') {
 		return ustalKlasęWpisywane(słowo, indeks, rozwiązanie.length)
 	}
 


### PR DESCRIPTION
## Summary
- replace loose equality/inequality operators with strict equivalents across game components
- ensure keyboard handling and result checks use type-safe comparisons

## Testing
- pnpm lint *(fails: ESLint configuration file eslint.config.js missing in repo)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f75094c148320b90c79700019b2db)